### PR TITLE
Extend liberator-mixin to support absolute urls with query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.0.13] — 2019-06-17
+- Made json->map and map->json public
+
 ## [0.0.11] — 2019-06-04
 
 ## [0.0.10] — 2019-05-22

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject b-social/liberator-mixin "0.0.12-SNAPSHOT"
+(defproject b-social/liberator-mixin "0.0.13-SNAPSHOT"
   :description "A collection of sensible defaults for liberator microservices."
   :url "https://github.com/b-social/liberator-mixin"
   :license {:name "The MIT License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject b-social/liberator-mixin "0.0.13"
+(defproject b-social/liberator-mixin "0.0.14-SNAPSHOT"
   :description "A collection of sensible defaults for liberator microservices."
   :url "https://github.com/b-social/liberator-mixin"
   :license {:name "The MIT License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject b-social/liberator-mixin "0.0.13-SNAPSHOT"
+(defproject b-social/liberator-mixin "0.0.13"
   :description "A collection of sensible defaults for liberator microservices."
   :url "https://github.com/b-social/liberator-mixin"
   :license {:name "The MIT License"

--- a/src/liberator_mixin/hypermedia/core.clj
+++ b/src/liberator_mixin/hypermedia/core.clj
@@ -3,6 +3,7 @@
     [clojure.string :as str]
 
     [bidi.bidi :refer [path-for]]
+    [ring.util.codec :refer [form-encode]]
     [liberator-mixin.core :as core]))
 
 (defn base-url [request]
@@ -15,6 +16,13 @@
   (str
     (base-url request)
     (apply path-for routes handler args)))
+
+(defn absolute-url-with-query-params-for
+  [request routes handler params & args]
+  (str
+    (apply absolute-url-for request routes handler args)
+    "?"
+    (form-encode params)))
 
 (defn parameterised-url-for
   [request routes handler parameter-names & args]

--- a/src/liberator_mixin/json/core.clj
+++ b/src/liberator_mixin/json/core.clj
@@ -34,13 +34,13 @@
 
 (add-encoder DateTime clj-time-encoder)
 
-(defn- json->map [string options]
+(defn json->map [string options]
   (let [meta-key-fn (or (:meta-key-fn options) keyword)
         standard-key-fn (or (:standard-key-fn options) ->kebab-case-keyword)]
     (json/parse-string string
       (if-metadata meta-key-fn standard-key-fn))))
 
-(defn- map->json [m options]
+(defn map->json [m options]
   (let [meta-key-fn (or (:meta-key-fn options) name)
         standard-key-fn (or (:standard-key-fn options) ->camelCaseString)]
     (json/generate-string m

--- a/test/liberator_mixin/hypermedia/core_test.clj
+++ b/test/liberator_mixin/hypermedia/core_test.clj
@@ -77,6 +77,30 @@
               (hypermedia/absolute-url-for request routes :example
                 :example-id 123))))))
 
+  (testing "absolute-url-with-query-params-for"
+    (testing "returns the absolute url for a route with params"
+      (let [request {:scheme :https
+                     :headers {"host" "example.com"}}
+            routes [""
+                    [["/" :root]
+                     ["/examples" :examples]]]
+            account "123"
+            params {:name account}]
+        (is (= (str "https://example.com/examples?name=" account)
+              (hypermedia/absolute-url-with-query-params-for request routes :examples params)))))
+
+    (testing "absolute-url-with-query-params-for expands arguments"
+      (let [request {:scheme :https
+                     :headers {"host" "example.com"}}
+            routes [""
+                    [["/" :root]
+                     [["/examples/" :example-id] :example]]]
+            account "123"
+            params {:name account}]
+        (is (= (str "https://example.com/examples/random-id?name=" account)
+              (hypermedia/absolute-url-with-query-params-for request routes
+                :example params :example-id "random-id"))))))
+
   (testing "parameterised-url-for"
     (testing "describes a single parameter"
       (let [request {:scheme :https


### PR DESCRIPTION
Authors: @elizabethvenner @tsetsova

We wanted to extend the functionality of absolute-url-for to include query params but because it is a variadic function, we could not overload the method and have instead added this as a separate function. 