### PR TITLE
Remove hype dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,30 +8,7 @@ and this project adheres to
 
 
 ## [Unreleased]
-### Removed
-Removed the functionality to automatically add the :discovery link to a halboy Resource.
-
-
-The identical functionality can be provided by adding the following snippet to the relevant service.
-```clojure
-;; :require
-;; [hype.core :as hype]
-;; [halboy.core :as hal]
-;; [halboy.json :as haljson]
-
-;; :import
-;; [halboy.resource Resource]
-
-(extend-protocol r/Representation
-  Resource
-  (as-response [data {:keys [request routes] :as context}]
-    (r/as-response
-      (-> data
-        (hal/add-link :discovery
-          (hype/absolute-url-for request routes :discovery))
-        (haljson/resource->map))
-      context)))
-```
+The hal.core functionality that implements Representation now requires a `discovery-url-fn` function to be included in the context.
 
 ## [0.0.65] — 2024-10-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ and this project adheres to
 
 
 ## [Unreleased]
-The hal.core functionality that implements Representation now requires a `discovery-url-fn` function to be included in the context.
+The hal.core functionality that implements Representation now requires a `discovery-url-fn` function to be included in the context if you want it to automatically add a discovery url to the resource. This can be achieved by adding the following mixin to your handler:
+
+```clojure
+(defn with-discovery-url-fn [_]
+  {:initialize-context
+   (fn [{:keys [request routes]}]
+     {:discovery-url-fn #(hype/absolute-url-for request routes :discovery)})})
+```
 
 ## [0.0.65] — 2024-10-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ and this project adheres to
 
 
 ## [Unreleased]
+### Removed
+Removed the functionality to automatically add the :discovery link to a halboy Resource.
+
+
+The identical functionality can be provided by adding the following snippet to the relevant service.
+```clojure
+;; :require
+;; [hype.core :as hype]
+;; [halboy.core :as hal]
+;; [halboy.json :as haljson]
+
+;; :import
+;; [halboy.resource Resource]
+
+(extend-protocol r/Representation
+  Resource
+  (as-response [data {:keys [request routes] :as context}]
+    (r/as-response
+      (-> data
+        (hal/add-link :discovery
+          (hype/absolute-url-for request routes :discovery))
+        (haljson/resource->map))
+      context)))
+```
 
 ## [0.0.65] — 2024-10-16
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 An extension to liberator allowing for composable mixins.
 
+## Upgrade to 1.x
+
+The change to version 1.x was done to denote a breaking change rather than signal a newly achieved degree of stability. The hal.core functionality that implements Representation now requires a `discovery-url-fn` function to be included in the context if you want it to automatically add a discovery url to the resource. This was done to avoid tying this library to the hype library, and thus to to the bidi router.
+
+To maintain prior behaviour, apply the following change to your code following the upgrade. Add this new mixin and include it as part of your resource:
+
+```clojure
+(defn with-discovery-url-fn []
+  {:initialize-context
+   (fn [{:keys [request routes]}]
+     {:discovery-url-fn #(hype/absolute-url-for request routes :discovery)})})
+```
+
+
 ## Install
 
 Add the following to your `project.clj` file:
@@ -13,10 +27,6 @@ Add the following to your `project.clj` file:
 ## Documentation
 
 * [API Docs](http://b-social.github.io/liberator-mixin)
-
-## Usage
-
-FIXME
 
 ## Contributing
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject b-social/liberator-mixin "0.0.66-SNAPSHOT"
+(defproject b-social/liberator-mixin "1.0.0-SNAPSHOT"
   :description "An extension to liberator allowing for composable mixins."
   :url "https://github.com/b-social/liberator-mixin"
 

--- a/project.clj
+++ b/project.clj
@@ -9,8 +9,6 @@
                  [buddy/buddy-auth "3.0.1"]
                  [liberator "0.15.3"]
                  
-                 [b-social/hype "1.0.0"]
-                 
                  [com.auth0/java-jwt "3.18.2"
                   :exclusions [com.fasterxml.jackson.core/jackson-databind]]
 

--- a/src/liberator_mixin/hal/core.clj
+++ b/src/liberator_mixin/hal/core.clj
@@ -42,12 +42,27 @@
   (:require
     [halboy.resource :as hal]
     [liberator.representation :as r]
+
+    [halboy.json :as haljson]
+
     [liberator-mixin.logging.core :as log]
-    [jason.convenience :as jason-conv]))
+    [jason.convenience :as jason-conv])
+  (:import
+    [halboy.resource Resource]))
 
 (def hal-media-type
   "The HAL media type string."
   "application/hal+json")
+
+(extend-protocol r/Representation
+  Resource
+  (as-response [data {:keys [url-for] :as context}]
+    (assert url-for "Missing url resolver fn url-for")
+    (r/as-response
+      (-> data
+        (hal/add-link :discovery (url-for :discovery))
+        (haljson/resource->map))
+      context)))
 
 (defmethod r/render-map-generic hal-media-type [data {:keys [json]}]
   ((get json :encoder jason-conv/->wire-json) data))

--- a/src/liberator_mixin/hal/core.clj
+++ b/src/liberator_mixin/hal/core.clj
@@ -57,12 +57,10 @@
 (extend-protocol r/Representation
   Resource
   (as-response [data {:keys [discovery-url-fn] :as context}]
-    (assert discovery-url-fn "Missing discovery-url-fn in context")
-    (r/as-response
-      (-> data
-          (hal/add-link :discovery (discovery-url-fn))
-        (haljson/resource->map))
-      context)))
+    (let [resource (if discovery-url-fn
+                     (hal/add-link data :discovery (discovery-url-fn))
+                     data)]
+      (r/as-response (haljson/resource->map resource) context))))
 
 (defmethod r/render-map-generic hal-media-type [data {:keys [json]}]
   ((get json :encoder jason-conv/->wire-json) data))

--- a/src/liberator_mixin/hal/core.clj
+++ b/src/liberator_mixin/hal/core.clj
@@ -42,33 +42,12 @@
   (:require
     [halboy.resource :as hal]
     [liberator.representation :as r]
-
-    [halboy.json :as haljson]
-
-    [hype.core :as hype]
-
     [liberator-mixin.logging.core :as log]
-    [jason.convenience :as jason-conv])
-  (:import
-    [halboy.resource Resource]
-    [java.util UUID]))
-
-(defn- random-uuid []
-  (str (UUID/randomUUID)))
+    [jason.convenience :as jason-conv]))
 
 (def hal-media-type
   "The HAL media type string."
   "application/hal+json")
-
-(extend-protocol r/Representation
-  Resource
-  (as-response [data {:keys [request routes] :as context}]
-    (r/as-response
-      (-> data
-        (hal/add-link :discovery
-          (hype/absolute-url-for request routes :discovery))
-        (haljson/resource->map))
-      context)))
 
 (defmethod r/render-map-generic hal-media-type [data {:keys [json]}]
   ((get json :encoder jason-conv/->wire-json) data))

--- a/src/liberator_mixin/hal/core.clj
+++ b/src/liberator_mixin/hal/core.clj
@@ -56,11 +56,11 @@
 
 (extend-protocol r/Representation
   Resource
-  (as-response [data {:keys [url-for] :as context}]
-    (assert url-for "Missing url resolver fn url-for")
+  (as-response [data {:keys [discovery-url-fn] :as context}]
+    (assert discovery-url-fn "Missing discovery-url-fn in context")
     (r/as-response
       (-> data
-        (hal/add-link :discovery (url-for :discovery))
+          (hal/add-link :discovery (discovery-url-fn))
         (haljson/resource->map))
       context)))
 


### PR DESCRIPTION
> [!NOTE]
> Note this would need to be a major upgrade as it is a breaking change, though the migration is straightforward (and this library has had _much_ worse breaking changes on minor releases).

The rationale for this is that this puts a hard dependency on hype and bidi as the underlying router. Removing it opens up migration to alternative routers (e.g. reitit) whilst maintaining the large majority of the liberator-focused functionality.