### PR TITLE
Exclude uritemplate-clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,6 +20,7 @@
                                http-kit.fake
                                tigris
                                cheshire
+                               uritemplate-clj
                                org.eclipse.jetty/jetty-server]]
                  
                  ;; brought in by cheshire for buddy-auth


### PR DESCRIPTION
It's unused by this library and it pulls in old versions of jetty with known vulnerabilities